### PR TITLE
added missing pages that are meant to display exrdisplay screenshots

### DIFF
--- a/view_02.html
+++ b/view_02.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+<title>exrdisplay with 0 exposure</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+</head>
+
+<body style="background: #000000">
+
+<a href="#" onClick="window.close();" class="roll"><img src="images/viewer_02.jpg" width="618" height="435" alt="exrdisplay with 0 exposure"><br>
+    <span style="font-family: Verdana, Arial, Helvetica, sans-serif">[close window]</span></a>
+
+</body>
+</html>
+

--- a/view_03.html
+++ b/view_03.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+<title>exrdisplay with Exposure Adjusted to +3</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+</head>
+
+<body style="background: #000000">
+
+<a href="#" onClick="window.close();" class="roll"><img src="images/viewer_03.jpg" width="618" height="435" alt="exrdisplay with exposure adjusted to positive 3"><br>
+    <span style="font-family: Verdana, Arial, Helvetica, sans-serif">[close window]</span></a>
+
+</body>
+</html>
+


### PR DESCRIPTION
[1] shows two thumbnails, but it leads to 404 when tried to enlarge by clicking on them. This commit adds back the missing files. Although the link to [1] seems to have removed from the home page, it is still present in other pages. So adding back these files will be useful, I think.

[1] https://www.openexr.com/using.html